### PR TITLE
fix: force reload bash in current terminal.

### DIFF
--- a/golang.sh
+++ b/golang.sh
@@ -36,3 +36,4 @@ echo "export PATH=\$PATH:/usr/local/go/bin" >> ~/.profile
 source ~/.profile > /dev/null 2>&1
 
 go version
+exec bash -il


### PR DESCRIPTION
Without this, the `go version` command works on script because make a `source .profile`, but when run `go version` and parent bash session this not works.
```terminal
utnso@d87c12aa0bee:~$ ./script.sh
++ get_latest_version
++ grep go
++ curl -s 'https://go.dev/VERSION?m=text'
+ VERSION=go1.22.5
+ sudo rm -rf /usr/local/go /usr/bin/go
++ uname -m
+ ARCH=aarch64
+ case $ARCH in
+ ARCH=arm64
+ URL=https://go.dev/dl/go1.22.5.linux-arm64.tar.gz
+ wget https://go.dev/dl/go1.22.5.linux-arm64.tar.gz -O /tmp/go.tar.gz
+ sudo tar -C /usr/local -xzf /tmp/go.tar.gz
+ echo 'export PATH=$PATH:/usr/local/go/bin'
+ source /home/utnso/.profile
+ go version
go version go1.22.5 linux/arm64
utnso@d87c12aa0bee:~$ go version
bash: go: command not found
```
With this change
```terminal
utnso@d87c12aa0bee:~$ ./script.sh
++ get_latest_version
++ grep go
++ curl -s 'https://go.dev/VERSION?m=text'
+ VERSION=go1.22.5
+ sudo rm -rf /usr/local/go /usr/bin/go
++ uname -m
+ ARCH=aarch64
+ case $ARCH in
+ ARCH=arm64
+ URL=https://go.dev/dl/go1.22.5.linux-arm64.tar.gz
+ wget https://go.dev/dl/go1.22.5.linux-arm64.tar.gz -O /tmp/go.tar.gz
+ sudo tar -C /usr/local -xzf /tmp/go.tar.gz
+ echo 'export PATH=$PATH:/usr/local/go/bin'
+ source /home/utnso/.profile
+ go version
go version go1.22.5 linux/arm64
+ exec bash -il
utnso@d87c12aa0bee:~$ go version
go version go1.22.5 linux/arm64
```