### PR TITLE
feat: Add network manager config

### DIFF
--- a/interfaz-grafica.sh
+++ b/interfaz-grafica.sh
@@ -16,12 +16,26 @@ xfce4-whiskermenu-plugin \
 xarchiver \
 terminator \
 mousepad \
+network-manager \
+network-manager-gnome \
 lightdm \
 lightdm-gtk-greeter \
 gpg \
 apt-transport-https \
 gnome-keyring \
 firefox
+
+# Network manager config
+mkdir -pv ~/.config/autostart
+
+cat > ~/.config/autostart/nm-applet.desktop << EOF
+[Desktop Entry]
+Version=1.0
+Type=Application
+Exec=nm-applet
+Terminal=false
+Name=Network Manager Applet
+EOF
 
 # Se obtiene el nombre de la última release de Eclipse y la arquitectura
 ECLIPSE_VERSION=$(curl -fsS https://eclipse.c3sl.ufpr.br/technology/epp/downloads/release/release.xml | grep -oPm1 "(?<=<present>)[^<]+")

--- a/interfaz-grafica.sh
+++ b/interfaz-grafica.sh
@@ -25,7 +25,7 @@ apt-transport-https \
 gnome-keyring \
 firefox
 
-# Network manager config
+# Se levanta el administrador de red al iniciar
 mkdir -pv ~/.config/autostart
 
 cat > ~/.config/autostart/nm-applet.desktop << EOF


### PR DESCRIPTION
Probé de instalar el entorno de forma nativa en una notebook y noté que le faltaba alguna GUI para conectarme a la WiFi (?)

En las VMs no es tan necesario igual, no sé si conviene agregarlo acá o armar un nuevo script opcional