### PR TITLE
fix: Remove unnecessary VSCode extensions

### DIFF
--- a/interfaz-grafica.sh
+++ b/interfaz-grafica.sh
@@ -75,6 +75,4 @@ fi
 # Se instalan las extensiones recomendadas
 code --install-extension ms-vscode.cpptools-extension-pack
 code --install-extension ms-vscode.hexeditor
-code --install-extension matepek.vscode-catch2-test-adapter
-code --install-extension eamodio.gitlens
 code --install-extension nhoizey.gremlins


### PR DESCRIPTION
Para las próximas VMs volaría estas 2 extensiones del default ya que:

- Al final catch2 test adapter para unit tests no se usa (en un principio la metí evaluando la posibilidad de usar algún que otro framework distinto a CSpec pero nada le gana)
- Quito GitLens porque si bien está buenísimo para VMs lentas le agrega mucha basura, sobre todo ni bien uno levanta VSCode por primera vez.

El que los quiera usar, que los sume, pero por default dejo lo mínimo necesario para debuggear
